### PR TITLE
fix: use custom colors from config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ const plugin = withOptions(
   },
   function (options = {}) {
     const defaultColors = options.defaultColors ?? false;
+    const customColors = options.customColors ?? {};
     const primaryColor = options.primaryColor ?? "carbon";
 
     const colorsObject = {
@@ -47,8 +48,9 @@ const plugin = withOptions(
           )
         : {}),
       ...colors,
+      ...customColors,
       gray: colors.carbon,
-      primary: colors[primaryColor],
+      primary: colors[primaryColor] ?? customColors[primaryColor],
     };
 
     return {


### PR DESCRIPTION
Adds support for the `customColors` object passed within the plugin config.